### PR TITLE
Remove unofficial link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # GM4_Resources
 Welcome to the repository for the Gamemode 4 resource pack. This pack is made to be completely optional, utilising the `CustomModelData` functionality. As a result, this resource pack is for Minecraft 1.14+.
 
-Looking for GM4's modules? Visit https://gm4.co/modules
+GM4 Datapacks: https://github.com/Gamemode4Dev/GM4_Datapacks
 
 For more information about Gamemode 4, visit https://www.gm4.co
 
-[Repository Standards](https://github.com/gm4-consortia/standards/tree/master/global_resource_pack)


### PR DESCRIPTION
The repository is now under the Gamemode4Dev organization, so this removes the link to the consortia repository and also adds a link to the GM4_Datapacks repository.