### PR TITLE
Use namespaced %1$s

### DIFF
--- a/base/assets/gm4/lang/en_us.json
+++ b/base/assets/gm4/lang/en_us.json
@@ -1,5 +1,5 @@
 {
-    "%1$s": "%2$s",
+    "%1$s%3427655$s": "%2$s",
 
     "lang.gm4.test": "GM4 Language Test",
     "lang.gm4.test.en.regional": "Color",


### PR DESCRIPTION
Use a namespaced `%1$s` to prevent conflicts with other packs using this language trick.

This number is calculated using the following formula, which gives `3427655` as result.
```python
ord("G") + 256*ord("M") + 256*256*ord("4")
```

This requires changes in the GM4_Datapacks repo: https://github.com/Gamemode4Dev/GM4_Datapacks/pull/241
Specifically, each occurrence of `%1$s` needs to be replaced with `%1$s%3427655$s`.
