### PR TITLE
Add loading screen colours

### DIFF
--- a/gm4_resources/assets/minecraft/optifine/color.properties
+++ b/gm4_resources/assets/minecraft/optifine/color.properties
@@ -1,0 +1,7 @@
+###############################################################################
+# Resource loading screen
+###############################################################################
+# Loading bar background color
+screen.loading.bar=5ba2c2
+# Loading bar foreground color
+screen.loading.progress=c3d9e4


### PR DESCRIPTION
Adds custom colours to the resource pack/initial game loading screen. This feature only works with [OptiFine](https://optifine.net), and was initially going to include a custom `mojang.png`; however, that was decided not to be added.

![image](https://user-images.githubusercontent.com/36608902/61181080-151b1380-a619-11e9-9d0f-4531b6ecf2dd.png)
